### PR TITLE
Ci/presign smoke fix

### DIFF
--- a/.github/workflows/scripts/smoke.ps1
+++ b/.github/workflows/scripts/smoke.ps1
@@ -6,9 +6,9 @@ $ErrorActionPreference = 'Stop'
 function Clean([string]$s) {
   if ($null -eq $s) { return '' }
   $t = $s.Trim()
-  $t = ($t -replace '^[\"'']|[\"'']$','')             # drop surrounding quotes
+  $t = ($t -replace '^[\"'']|[\"'']$','')
   $bytes = [Text.Encoding]::UTF8.GetBytes($t)
-  $bytes = $bytes | Where-Object { $_ -notin 0,10,13 } # strip NUL/LF/CR
+  $bytes = $bytes | Where-Object { $_ -notin 0,10,13 }
   [Text.Encoding]::UTF8.GetString([byte[]]$bytes)
 }
 
@@ -42,7 +42,6 @@ Write-Host "`n--- Presign request debug ---"
 Write-Host "URI: $uri"
 Write-Host "Body: $bodyJson"
 
-# Build headers AFTER sanitizing. Do NOT use Invoke-WebRequest.
 $headers = @{ 'x-api-key' = $apiKey }
 
 if ($secret) {

--- a/.github/workflows/upload-smoke.yml
+++ b/.github/workflows/upload-smoke.yml
@@ -1,38 +1,8 @@
-name: Upload smoke
-
-on:
-  workflow_dispatch:
-
-jobs:
-  presign_and_upload:
-    runs-on: ubuntu-latest
-    # Export repo secrets into env that the script expects
-    env:
-      PRESIGN_API_BASE: ${{ secrets.PRESIGN_API_BASE }}
-      PRESIGN_ENDPOINT:  ${{ secrets.PRESIGN_ENDPOINT }}
-      PRESIGN_HMAC_SECRET: ${{ secrets.PRESIGN_HMAC_SECRET }}
-      PRESIGN_API_KEY:   ${{ secrets.PRESIGN_API_KEY }}   # if your API needs it
-      CF_BASE_URL:       ${{ secrets.CF_BASE_URL }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Sanity-check inputs (masked)
-        shell: pwsh
-        run: |
-          Write-Host "API_BASE length: $(${env:PRESIGN_API_BASE}.Length)"
-          Write-Host "ENDPOINT  length: $(${env:PRESIGN_ENDPOINT}.Length)"
-          Write-Host "SECRET    length: $(${env:PRESIGN_HMAC_SECRET}.Length)"
-          Write-Host "API_KEY   length: $(${env:PRESIGN_API_KEY}.Length)"
-          Write-Host "CF_BASE   length: $(${env:CF_BASE_URL}.Length)"
-
       - name: Presign + upload (PowerShell)
         shell: pwsh
         run: .github/workflows/scripts/presign-smoke.ps1
-
-      - name: Show generated URL (if any)
-        if: always()
-        shell: pwsh
-        run: |
-          if (Test-Path ./public-url.txt) { Get-Content ./public-url.txt }
+        env:
+          PRESIGN_API_BASE:   ${{ secrets.PRESIGN_API_BASE }}
+          PRESIGN_ENDPOINT:   ${{ secrets.PRESIGN_ENDPOINT }}   # optional
+          PRESIGN_API_KEY:    ${{ secrets.PRESIGN_API_KEY }}
+          PRESIGN_HMAC_SECRET:${{ secrets.PRESIGN_HMAC_SECRET }}# optional

--- a/.github/workflows/upload-smoke.yml
+++ b/.github/workflows/upload-smoke.yml
@@ -1,8 +1,8 @@
       - name: Presign + upload (PowerShell)
         shell: pwsh
-        run: .github/workflows/scripts/presign-smoke.ps1
+        run: .github/workflows/scripts/smoke.ps1
         env:
-          PRESIGN_API_BASE:   ${{ secrets.PRESIGN_API_BASE }}
-          PRESIGN_ENDPOINT:   ${{ secrets.PRESIGN_ENDPOINT }}   # optional
-          PRESIGN_API_KEY:    ${{ secrets.PRESIGN_API_KEY }}
-          PRESIGN_HMAC_SECRET:${{ secrets.PRESIGN_HMAC_SECRET }}# optional
+          PRESIGN_API_BASE:    ${{ secrets.PRESIGN_API_BASE }}
+          PRESIGN_ENDPOINT:    ${{ secrets.PRESIGN_ENDPOINT }}     # optional
+          PRESIGN_API_KEY:     ${{ secrets.PRESIGN_API_KEY }}
+          PRESIGN_HMAC_SECRET: ${{ secrets.PRESIGN_HMAC_SECRET }}  # optional


### PR DESCRIPTION
- Replace Invoke-WebRequest (+UseBasicParsing) with Invoke-RestMethod to avoid
  "New-line characters are not allowed in header values" on GitHub runners.
- Build the JSON body with ConvertTo-Json (no manual quoting).
- Log only lengths of secrets (no secret values).
- Normalize env var names and strict fail on missing ones.
- Cleaner error output + shows generated URL when available.

Affected:
- .github/workflows/scripts/smoke.ps1
- .github/workflows/upload-smoke.yml
- (legacy ***-smoke.ps1 removed)
